### PR TITLE
Remove revision-info from charmstore requests.

### DIFF
--- a/lib/charmstore.js
+++ b/lib/charmstore.js
@@ -160,7 +160,6 @@ charmstore.prototype = {
         charmMeta = meta['charm-metadata'],
         charmConfig = meta['charm-config'],
         commonInfo = meta['common-info'],
-        revisionInfo = meta['revision-info'] || {},
         bundleMeta = meta['bundle-metadata'],
         published = meta['published'] || {},
         tags = meta['tags'] || {},
@@ -175,7 +174,6 @@ charmstore.prototype = {
       // If the id has a user segment then it has not been promulgated.
       is_approved: data.Id.indexOf('~') > 0 ? false : true,
       owner: owner,
-      revisions: revisionInfo.Revisions || [],
       tags: tags.Tags || [],
       supported: extraInfo.supported === 'true',
       price: extraInfo.price,
@@ -347,7 +345,6 @@ charmstore.prototype = {
       'owner',
       'published',
       'resources',
-      'revision-info',
       'stats',
       'supported-series',
       'tags'

--- a/lib/test-charmstore.js
+++ b/lib/test-charmstore.js
@@ -167,9 +167,6 @@ tap.test('_processEntityQueryData', t => {
           price: '8',
           description: 'supported description'
         },
-        'revision-info': {
-          Revisions: ['rev1', 'rev2', 'rev4']
-        },
         'charm-config': {
           Options: {
             'foo-optn': {
@@ -223,7 +220,6 @@ tap.test('_processEntityQueryData', t => {
         metric: 'metric'
       },
       owner: 'hatch',
-      revisions: ['rev1', 'rev2', 'rev4'],
       supported: true,
       price: '8',
       supportedDescription: 'supported description',
@@ -279,7 +275,6 @@ tap.test('_processEntityQueryData', t => {
     const processed = charmstoreInstance._processEntityQueryData(data);
     t.strictEqual(processed.owner, undefined);
     t.strictEqual(processed.code_source.location, undefined);
-    t.deepEqual(processed.revisions, []);
     t.end();
   });
 
@@ -303,9 +298,6 @@ tap.test('_processEntityQueryData', t => {
           price: '8',
           description: 'supported description'
         },
-        'revision-info': {
-          Revisions: ['rev1', 'rev2']
-        },
         stats: {
           ArchiveDownloadCount: 10
         }
@@ -326,7 +318,6 @@ tap.test('_processEntityQueryData', t => {
       is_approved: false,
       name: 'mongodb-cluster',
       owner: 'hatch',
-      revisions: ['rev1', 'rev2'],
       services: '',
       supported: true,
       price: '8',
@@ -656,7 +647,6 @@ tap.test('getEntity', t => {
       '&include=owner' +
       '&include=published' +
       '&include=resources' +
-      '&include=revision-info' +
       '&include=stats' +
       '&include=supported-series' +
       '&include=tags'


### PR DESCRIPTION
Requests that include `revision-info` frequently time out because of the large amount of data returned. This removes the `revision-info` field from the request. 